### PR TITLE
good-scanner: remove multi-line example

### DIFF
--- a/good-scanner/CMakeLists.txt
+++ b/good-scanner/CMakeLists.txt
@@ -7,10 +7,7 @@ add_library(good-scanner
 
     # Simple modules for use in other sources.
     mod.mpp
-    other.mpp
-
-    # Import multiple modules on the same line.
-    multi-line.mpp)
+    other.mpp)
 
 add_executable(define-mod
     define.mpp)

--- a/good-scanner/multi-line.mpp
+++ b/good-scanner/multi-line.mpp
@@ -1,5 +1,0 @@
-import mod; import other;
-
-int multiline() {
-    return modfunc() + otherfunc();
-}


### PR DESCRIPTION
It's no longer valid.